### PR TITLE
Add query dynamodb policy to fanout role

### DIFF
--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -254,6 +254,7 @@ function deployFanout {
           cd "$OLD"
           exit -1
         fi
+        aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AmazonDynamoDBReadOnlyAccess ${CLI_PARAMS[@]}
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole ${CLI_PARAMS[@]}
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole ${CLI_PARAMS[@]}
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole ${CLI_PARAMS[@]}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
         "async": "1.5.2"
     }, 
     "description": "An Amazon Kinesis Streams and Amazon DynamoDB Streams pipeline written for AWS Lambda", 
+    "scripts" : {
+        "test": "mocha"
+    },
     "devDependencies": {
         "mocha": "2.4.5",
         "aws-sdk": "2.2.19"


### PR DESCRIPTION
Fanout must be able to query the DynamoDB.