### PR TITLE
Corrected user policy arn for AmazonDynamoDBReadOnlyAccess

### DIFF
--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -254,7 +254,7 @@ function deployFanout {
           cd "$OLD"
           exit -1
         fi
-        aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AmazonDynamoDBReadOnlyAccess ${CLI_PARAMS[@]}
+        aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess ${CLI_PARAMS[@]}
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole ${CLI_PARAMS[@]}
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole ${CLI_PARAMS[@]}
         aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole ${CLI_PARAMS[@]}


### PR DESCRIPTION
The arn policy for AmazonDynamoDBReadOnlyAccess is incorrect in the file: cli/functions.sh. It should be:
`aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess ${CLI_PARAMS[@]}`
instead of:
`aws iam attach-role-policy --role-name $EXEC_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AmazonDynamoDBReadOnlyAccess ${CLI_PARAMS[@]}`