### PR TITLE
fixes external role arn detection and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The `register <type>` command creates a new mapping for an existing `fanout func
 * `--index <doctype/index>` (optional, required only for `es` with domain name) specify, for Amazon Elasticsearch Service, the index in the domain where the data will reside
 * `--destination-region <us-west-2>` (optional) specify the `target region` for this mapping
 * `--active <true|false>` (optional, default false) indicates if this target is active or not
-* `--role-arn <arn:aws:iam::0123456789abcdef::role/targetRole>` (optional) specify, for cross-account roles, the role ARN that will be assumed
+* `--destination-role-arn <arn:aws:iam::0123456789abcdef::role/targetRole>` (optional) specify, for cross-account roles, the role ARN that will be assumed
 * `--external-id <123456>` (optional) specify, for cross-account roles, an external Id for the STS:AssumeRole call
 * `--collapse <none|JSON|concat|concat-b64>` (optional, default JSON) for AWS IoT, Amazon SQS and Amazon SNS, defines how the messages should be collapsed, if at all
 * `--parallel <true|false>` (optional, default true) indicates if we should process sending these messages in parallel
@@ -247,7 +247,7 @@ The `update` command allows you to modify some parameters of your mappings. As t
     * When `--source` is used, you must specify `--source-type` as well
 * `--id <mapping-id>` (required) specify the identifier of this mapping
 * `--active <true|false>` (optional) indicates if this target is active or not
-* `--role-arn <arn:aws:iam::0123456789abcdef::role/targetRole>` (optional) specify, for cross-account roles, the role ARN that will be assumed
+* `--destination-role-arn <arn:aws:iam::0123456789abcdef::role/targetRole>` (optional) specify, for cross-account roles, the role ARN that will be assumed
 * `--external-id <123456>` (optional) specify, for cross-account roles, an external Id for the STS:AssumeRole call
 * `--collapse <none|JSON|concat|concat-b64>` (optional, default JSON) for AWS IoT, Amazon SQS and Amazon SNS, defines how the messages should be collapsed, if at all
 * `--parallel <true|false>` (optional) indicates if we should process sending these messages in parallel

--- a/fanout
+++ b/fanout
@@ -36,7 +36,7 @@ function checkLambdaTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | sed -E -n 's#^arn:aws:lambda:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:function:([a-zA-Z0-9_-]{1,64})$#\1#p' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid ARN '${DESTINATION_NAME}', must be a fully qualified AWS Lambda Function ARN" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on functions within your local user" 1>&2
         exit -1
@@ -56,7 +56,7 @@ function checkKinesisTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | sed -E -n 's#^arn:aws:kinesis:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:stream/([a-zA-Z0-9_-]{1,128})$#\1#p' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid ARN '${DESTINATION_NAME}', must be a fully qualified Amazon Kinesis Stream ARN" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on streams within your local user" 1>&2
         exit -1
@@ -76,7 +76,7 @@ function checkFirehoseTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | sed -E -n 's#^arn:aws:firehose:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:deliverystream/([a-zA-Z0-9_-]{1,64})$#\1#p' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid ARN '${DESTINATION_NAME}', must be a fully qualified Amazon Kinesis Firehose Delivery Stream ARN" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on streams within your local user" 1>&2
         exit -1
@@ -96,7 +96,7 @@ function checkSqsTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | grep -E -e '^https://((queue)|(sqs\.[a-z]+-[a-z]+-[0-9]))\.amazonaws\.com/[0-9]{12}/[a-zA-Z0-9_-]{1,80}$' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid url '${DESTINATION_NAME}', must be a fully qualified Amazon SQS Queue Url" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on queues within your local user" 1>&2
         exit -1
@@ -116,7 +116,7 @@ function checkIotTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | grep -E '^[a-zA-Z0-9-]+\.iot\.[a-z]+-[a-z]+-[0-9]\.amazonaws\.com#.*$' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid configuration '${DESTINATION_NAME}', must be a fully qualified Amazon IoT Endpoint followed by an MQTT topic name (separated by #)" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on topics within your local user" 1>&2
         exit -1
@@ -132,7 +132,7 @@ function checkSnsTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | grep -E -e '^arn:aws:sns:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:[a-zA-Z0-9_-][a-zA-Z0-9_-]{0,255}$' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid ARN '${DESTINATION_NAME}', must be a fully qualified Amazon SNS Topic ARN" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on topics within your local user" 1>&2
         exit -1
@@ -152,7 +152,7 @@ function checkMemcachedTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | grep -E -e '^[a-zA-Z][a-zA-Z0-9-]{0,19}\.[a-z0-9]+\.cfg\.[a-z]+[0-9]\.cache\.amazonaws\.com:[0-9]+$' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid endpoint '${DESTINATION_NAME}', must be a valid Amazon ElastiCache cluster endpoint in the format <configuration-endpoint>:<port>" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on topics within your local user" 1>&2
         exit -1
@@ -172,7 +172,7 @@ function checkRedisTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | grep -E -e '^[a-zA-Z][a-zA-Z0-9-]{0,19}\.[a-z0-9]+\.ng\.[0-9]+\.[a-z]+[0-9]\.cache\.amazonaws\.com:[0-9]+$' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid endpoint '${DESTINATION_NAME}', must be a valid Amazon ElastiCache replication group primary endpoint in the format <primary-endpoint>:<port>" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on clusters within your local user" 1>&2
         exit -1
@@ -192,7 +192,7 @@ function checkEsTarget {
   if [ ! -z "$DESTINATION_NAME" ]; then
     DESTINATION_ID=$( echo "$DESTINATION_NAME" | grep -E -e '^search-[a-z][a-z0-9-]{2,27}-[a-z0-9]+\.[a-z]+-[a-z]+-[0-9]\.es\.amazonaws\.com#.*$' )
     if [ -z "${DESTINATION_ID}" ]; then
-      if [ ! -z "${DESTINATION_ROLE}" ]; then
+      if [ ! -z "${DESTINATION_ROLE_ARN}" ]; then
         echo "Invalid endpoint '${DESTINATION_NAME}', must be a fully qualified Amazon Elasticsearch Service Domain endpoint followed by '#' then the index name" 1>&2
         echo " - You specified a Role ARN, and name expansion can only be made on domains within your local user" 1>&2
         exit -1

--- a/fanout
+++ b/fanout
@@ -271,6 +271,7 @@ if [ "$ACTION" == "register" ]; then
   registerFanoutTarget ${PASSTHROUGH[@]}
 elif [ "$ACTION" == "update" ]; then
   readCliParams $@
+  readTargetParams ${PASSTHROUGH[@]}
   readObjectProperties ${PASSTHROUGH[@]}
   readFunctionParams ${PASSTHROUGH[@]}
   readWorkerParams ${PASSTHROUGH[@]}


### PR DESCRIPTION
The `fanout` CLI was checking `DESTINATION_ROLE` but that is never populated.  Instead it should check `DESTINATION_ROLE_ARN`.  Also the `README.md` mentioned a `--role-arn` switch on the `register` and `update` commands, but that switch is never checked.  Instead it should have been `--destination-role-arn`.  Both changes are in this PR.  Additionally the `update` command never pulled `--destination-role-arn` off of the arguments so it appeared unexpected.