### PR TITLE
adds --apend-newlines target option to append newlines to DynamoDB records

### DIFF
--- a/cli/help.sh
+++ b/cli/help.sh
@@ -101,6 +101,7 @@ function helpObjectProperties {
   echo "  --parallel <flag>: processes multiple messages in parallel for efficiency" 1>&2
   echo "  --convert-ddb <flag>: for Amazon DynamoDB Streams messages, converts the DDB objects to plain JavaScript objects" 1>&2
   echo "  --deaggregate <flag>: for Amazon Kinesis Streams messages, deserializes KPL (protobuf-based) messages" 1>&2
+  echo "  --append-newlines <flag>: for Amazon DynamoDB Streams messages, append a newline to the end of each record" 1>&2
 }
 
 function helpTargetParams {

--- a/cli/targets.sh
+++ b/cli/targets.sh
@@ -281,6 +281,7 @@ function readObjectProperties {
   PARALLEL=
   CONVERT_DDB=
   DEAGGREGATE=
+  APPEND_NEWLINES=
 
   while [ $# -ne 0 ]; do
     CODE=$1
@@ -330,6 +331,15 @@ function readObjectProperties {
         doHelp
         exit -1
       fi
+    elif [ "$CODE" == "--append-newlines" ]; then
+      if [ $# -ne 0 ]; then
+        APPEND_NEWLINES=$1
+        shift
+      else
+        echo "readObjectProperties: You must specify a value for parameter $CODE" 1>&2
+        doHelp
+        exit -1
+      fi
     elif [[ "$CODE" =~ ^--.* ]]; then
       PASSTHROUGH+=($CODE)
       if [ $# -ne 0 ]; then
@@ -367,6 +377,11 @@ function readObjectProperties {
   fi
   if [ ! -z "${DEAGGREGATE}" ] && [ "${DEAGGREGATE}" != "true" ] && [ "${DEAGGREGATE}" != "false" ]; then
     echo "readObjectProperties: invalid boolean property --deaggregate $PARALLEL, must be one of (true, false)" 1>&2
+    doHelp
+    exit -1
+  fi
+  if [ ! -z "${APPEND_NEWLINES}" ] && [ "${APPEND_NEWLINES}" != "true" ] && [ "${APPEND_NEWLINES}" != "false" ]; then
+    echo "readObjectProperties: invalid boolean property --append-newlines $APPEND_NEWLINES, must be one of (true, false)" 1>&2
     doHelp
     exit -1
   fi
@@ -436,6 +451,9 @@ function buildObject {
   fi
   if [ ! -z "${DEAGGREGATE}" ]; then
     appendJsonProperty "$1" "deaggregate" "{\"BOOL\":${DEAGGREGATE}}"
+  fi
+  if [ ! -z "${APPEND_NEWLINES}" ]; then
+    appendJsonProperty "$1" "appendNewlines" "{\"BOOL\":${APPEND_NEWLINES}}"
   fi
 }
 

--- a/lib/transformation.js
+++ b/lib/transformation.js
@@ -31,7 +31,7 @@ function transformDDBRecord(record, target, callback) {
   try {
     var entry = (record.dynamodb.hasOwnProperty("NewImage") ? record.dynamodb.NewImage : {});
     var object = target.convertDDB ? DDB.parseDynamoDBObject(entry) : entry;
-    var data = new Buffer(JSON.stringify(object), 'utf-8');
+    var data = new Buffer(JSON.stringify(object) + (target.appendNewlines ? "\n" : ''), 'utf-8');
     var keys = Object.keys(record.dynamodb.Keys);
     var keyEntry = DDB.parseDynamoDBObject(record.dynamodb.Keys);
     var key = "";


### PR DESCRIPTION
It's pretty common for me to send DynamoDB records to Firehose to be picked up by an EMR job, and the EMR JSON SerDe expects newlines between JSON records.

I'm not sure if this will be useful to others, but I have a hunch it's a pretty common workflow.

I didn't add this support to Kinesis Streams because I'm not sure if it makes sense there.  If it is sensible then It's probably just a base64 decode, append newline, base64 encode.