### PR TITLE
adds env var DDB table workaround for custom table names

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -40,7 +40,7 @@ var DDB = require('./ddb-utils.js');
 
 // Default values
 var defaultValues = {
-  configurationTable : process.env.AWS_LAMBDA_FUNCTION_NAME + 'Targets', // DynamoDB Table holding the list of targets for this function
+  configurationTable : process.env.TABLE_NAME, // DynamoDB Table holding the list of targets for this function
   configRefreshDelay : 5*60*1000,                                        // Reload configuration once very 5 minutes
   debug              : false                                             // Activate debug messages
 };


### PR DESCRIPTION
Ran into a similar issue as: https://github.com/awslabs/aws-lambda-fanout/issues/23

Attempted a hacky workaround leveraging lambda environment variables. Goal was minimal changes to the current process flow.

Not currently backwards compatible.