### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The `deploy` command creates the `fanout function` and supporting resources (AWS
 * `--exec-role <fanoutRole>` (optional) specify the AWS IAM Role to use for the `fanout function`. The role is created if it does not exist.
     * You can specify the role by ARN and avoid role detection and creation by using `--exec-role-arn <arn:aws:iam::0123456789abcdef::role/fanoutRole>`
 * `--memory <128>` (optional, default 128) specify the amount of memory (in MiB) to use for the function
-* `--runtime <nodejs10.x>` (optional, default `nodejs10.x`) specify the runtime environment for the Lambda function
+* `--runtime <nodejs14.x>` (optional, default `nodejs14.x`) specify the runtime environment for the Lambda function
 * `--timeout <30>` (optional, default 30) specify the timeout of the function (in seconds)
 
 

--- a/cli/functions.sh
+++ b/cli/functions.sh
@@ -129,7 +129,7 @@ function readFunctionConfigParams {
   MEMORY_SIZE=128
   TIMEOUT=30
   SECURITY_GROUPS=
-  RUNTIME=nodejs10.x
+  RUNTIME=nodejs14.x
 
   while [ $# -ne 0 ]; do
     CODE=$1


### PR DESCRIPTION
CloudFormation templates in aws-lambda-fanout have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.